### PR TITLE
Parse proxy rules.

### DIFF
--- a/src/Redirects/Parser.elm
+++ b/src/Redirects/Parser.elm
@@ -20,6 +20,7 @@ type alias Target =
     { url : Url
     , status : Int
     , force : Bool
+    , proxy : Bool
     }
 
 
@@ -129,8 +130,14 @@ newTarget target status =
     let
         ( code, force ) =
             parseStatus status
+
+        url =
+            Erl.parse target
+
+        proxy =
+            (fullUrl url.protocol) && code == 200
     in
-        (Target (Erl.parse target) code force)
+        (Target url code force proxy)
 
 
 parseConditions : List String -> Conditions
@@ -170,4 +177,9 @@ notComment part =
 
 notValidStatus : String -> Bool
 notValidStatus status =
-    not (Regex.contains (regex "(200|301|302|303|404)!?") status)
+    not (Regex.contains (regex "(200|301|302|303|307|404)!?") status)
+
+
+fullUrl : String -> Bool
+fullUrl protocol =
+    Regex.contains (regex "^https?") protocol

--- a/tests/Redirects/Tests.elm
+++ b/tests/Redirects/Tests.elm
@@ -72,7 +72,7 @@ all =
                             filterRule "/foo qux=quux /bar 302!"
                     in
                         expectParsedRule rule <|
-                            \rule -> Expect.equal ( 302, True ) ( rule.target.status, rule.target.force )
+                            \rule -> Expect.equal ( 302, True, False ) ( rule.target.status, rule.target.force, rule.target.proxy )
             , test "origin URL, parameters, target URL, status and filters" <|
                 \() ->
                     let
@@ -81,6 +81,14 @@ all =
                     in
                         expectParsedRule rule <|
                             \rule -> Expect.equal (Dict.fromList [ ( "Country", "en,es" ), ( "Language", "es" ) ]) (rule.filters)
+            , test "origin URL and proxy target" <|
+                \() ->
+                    let
+                        rule =
+                            filterRule "/foo http://foo.com/bar 200"
+                    in
+                        expectParsedRule rule <|
+                            \rule -> Expect.equal ( 200, True ) ( rule.target.status, rule.target.proxy )
             ]
         ]
 


### PR DESCRIPTION
- Targets which URL is absolute and status code is 200 are considered
  proxy rules.

Signed-off-by: David Calavera <david.calavera@gmail.com>