### PR TITLE
Use var rather than const.

### DIFF
--- a/src/Native/Ace.js
+++ b/src/Native/Ace.js
@@ -143,8 +143,8 @@ function render(model) {
 	};
 
 	if (model.placeholder) {
-    const placeholder = model.placeholder.replace(/\n\r?/g, "<br>").replace(/\s/g, "&nbsp;");
-    var updatePlaceholder = function() {
+      var placeholder = model.placeholder.replace(/\n\r?/g, "<br>").replace(/\s/g, "&nbsp;");
+      var updatePlaceholder = function() {
       var shouldShow = !editor.session.getValue().length;
       var node = editor.renderer.emptyMessageNode;
       if (!shouldShow && node) {


### PR DESCRIPTION
Because we don't preprocess that JS and safari doesn't like it.

Fixes #7.

Signed-off-by: David Calavera <david.calavera@gmail.com>