### PR TITLE
Fix status regex

### DIFF
--- a/src/Url.elm
+++ b/src/Url.elm
@@ -15,4 +15,4 @@ validPattern part =
 
 validStatus : String -> Bool
 validStatus status =
-    (contains (regex "^200|301|302|303|307|404|4\\d\\d!?$") status)
+    (contains (regex "^(200|301|302|303|307|404|4\\d\\d)!?$") status)


### PR DESCRIPTION
Without the parenthesis, the anchor `^` is only applied to 200, and the `!?` is only applied to 4xx.
