### PR TITLE
Decode URIs after dumping the toml format.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,6 +12,7 @@
         "elm-community/list-extra": "6.0.0 <= v < 7.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "elm-lang/navigation": "2.0.1 <= v < 3.0.0",
         "evancz/url-parser": "2.0.1 <= v < 3.0.0",
         "sporto/erl": "10.0.2 <= v < 11.0.0"

--- a/elm-package.json
+++ b/elm-package.json
@@ -14,8 +14,7 @@
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "elm-lang/navigation": "2.0.1 <= v < 3.0.0",
-        "evancz/url-parser": "2.0.1 <= v < 3.0.0",
-        "sporto/erl": "10.0.2 <= v < 11.0.0"
+        "evancz/url-parser": "2.0.1 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Erl.elm
+++ b/src/Erl.elm
@@ -1,0 +1,726 @@
+module Erl
+    exposing
+        ( addQuery
+        , appendPathSegments
+        , clearQuery
+        , extractHash
+        , extractHost
+        , extractPath
+        , extractPort
+        , extractProtocol
+        , extractQuery
+        , getQueryValuesForKey
+        , new
+        , parse
+        , Query
+        , queryToString
+        , removeQuery
+        , setQuery
+        , toString
+        , toAbsoluteString
+        , Url
+        )
+
+{-| Library for parsing and constructing URLs
+
+
+# Types
+
+@docs Url, Query
+
+
+# Parse
+
+@docs parse
+
+
+# Parse helpers
+
+@docs extractHash, extractHost, extractPath, extractProtocol, extractPort, extractQuery
+
+
+# Construct
+
+@docs new
+
+
+# Mutation helpers
+
+@docs addQuery, setQuery, removeQuery, clearQuery, appendPathSegments
+
+
+# Serialize
+
+@docs toString, toAbsoluteString
+
+
+# Serialization helpers
+
+@docs queryToString
+
+
+# Other helpers
+
+@docs getQueryValuesForKey
+
+-}
+
+import Dict
+import Erl.Query
+import Erl.Types as Types
+import Http
+import Regex
+import String exposing (..)
+
+
+-- TYPES
+
+
+{-| List of tuples that holds the keys and values in the query string
+-}
+type alias Query =
+    Types.Query
+
+
+{-| Record that holds url attributes
+-}
+type alias Url =
+    { protocol : String
+    , username : String
+    , password : String
+    , host : List String
+    , port_ : Int
+    , path : List String
+    , hasLeadingSlash : Bool
+    , hasTrailingSlash : Bool
+    , hash : String
+    , query : Query
+    }
+
+
+
+-- UTILS
+
+
+notEmpty : String -> Bool
+notEmpty str =
+    not (isEmpty str)
+
+
+
+-- "aa#bb" --> "bb"
+
+
+rightFrom : String -> String -> String
+rightFrom delimiter str =
+    let
+        parts =
+            split delimiter str
+    in
+        case List.length parts of
+            0 ->
+                ""
+
+            1 ->
+                ""
+
+            _ ->
+                parts
+                    |> List.reverse
+                    |> List.head
+                    |> Maybe.withDefault ""
+
+
+rightFromLeftMost : String -> String -> String
+rightFromLeftMost delimiter str =
+    let
+        parts =
+            split delimiter str
+    in
+        case List.length parts of
+            0 ->
+                ""
+
+            1 ->
+                ""
+
+            _ ->
+                parts
+                    |> List.tail
+                    |> Maybe.withDefault []
+                    |> join delimiter
+
+
+rightFromOrSame : String -> String -> String
+rightFromOrSame delimiter str =
+    let
+        parts =
+            split delimiter str
+    in
+        parts
+            |> List.reverse
+            |> List.head
+            |> Maybe.withDefault ""
+
+
+
+-- "a/b" -> "a"
+-- "a"   => "a"
+-- "/b"  => ""
+
+
+leftFromOrSame : String -> String -> String
+leftFromOrSame delimiter str =
+    let
+        parts =
+            split delimiter str
+    in
+        parts
+            |> List.head
+            |> Maybe.withDefault ""
+
+
+
+-- "a/b" -> "a"
+-- "/b"  -> ""
+-- "a"   -> ""
+
+
+leftFrom : String -> String -> String
+leftFrom delimiter str =
+    let
+        parts =
+            split delimiter str
+
+        head =
+            List.head parts
+    in
+        case List.length parts of
+            0 ->
+                ""
+
+            1 ->
+                ""
+
+            _ ->
+                head |> Maybe.withDefault ""
+
+
+
+-- PROTOCOL
+
+
+{-| Extract the protocol from the url
+-}
+extractProtocol : String -> String
+extractProtocol str =
+    let
+        parts =
+            split "://" str
+    in
+        case List.length parts of
+            1 ->
+                ""
+
+            _ ->
+                Maybe.withDefault "" (List.head parts)
+
+
+
+-- HOST
+-- valid host: a-z 0-9 and -
+
+
+{-| Extract the host from the url
+-}
+extractHost : String -> String
+extractHost str =
+    -- if str starts with // or contains :// then we can assume that what follows is the host
+    -- if it doesn't then look for tld
+    let
+        delim =
+            schemeHostDelim str
+    in
+        case delim of
+            Just delim ->
+                str
+                    |> rightFromLeftMost delim
+                    |> leftFromOrSame "/"
+                    |> leftFromOrSame ":"
+
+            Nothing ->
+                let
+                    -- Look for something with a dot e.g. host.tld
+                    rx =
+                        "((\\w|-)+\\.)+(\\w|-)+"
+                in
+                    str
+                        |> leftFromOrSame "/"
+                        |> Regex.find (Regex.AtMost 1) (Regex.regex rx)
+                        |> List.map .match
+                        |> List.head
+                        |> Maybe.withDefault ""
+
+
+schemeHostDelim : String -> Maybe String
+schemeHostDelim str =
+    if String.startsWith "//" str then
+        Just "//"
+    else if String.contains "://" str then
+        Just "://"
+    else
+        Nothing
+
+
+parseHost : String -> List String
+parseHost str =
+    str
+        |> split "."
+
+
+host : String -> List String
+host str =
+    parseHost (extractHost str)
+
+
+
+-- PORT
+
+
+{-| Extract the port from the url
+
+If no port is included in the url then Erl will attempt to add a default port:
+
+Http -> 80
+Https -> 443
+FTP -> 21
+SFTP -> 22
+
+-}
+extractPort : String -> Int
+extractPort str =
+    let
+        rx =
+            Regex.regex ":\\d+"
+
+        res =
+            Regex.find (Regex.AtMost 1) rx str
+    in
+        res
+            |> List.map .match
+            |> List.head
+            |> Maybe.withDefault ""
+            |> String.dropLeft 1
+            |> toInt
+            |> \result ->
+                case result of
+                    Ok port_ ->
+                        port_
+
+                    _ ->
+                        case extractProtocol str of
+                            "http" ->
+                                80
+
+                            "https" ->
+                                443
+
+                            "ftp" ->
+                                21
+
+                            "sftp" ->
+                                22
+
+                            _ ->
+                                0
+
+
+
+-- PATH
+
+
+{-| Extract the path from the url
+-}
+extractPath : String -> String
+extractPath str =
+    let
+        host =
+            extractHost str
+
+        delim =
+            schemeHostDelim str
+
+        trimmed =
+            case delim of
+                Just delim ->
+                    rightFromLeftMost delim str
+
+                Nothing ->
+                    str
+    in
+        trimmed
+            |> leftFromOrSame "?"
+            |> leftFromOrSame "#"
+            |> Regex.replace (Regex.AtMost 1) (Regex.regex ("^.*?" ++ (Regex.escape host) ++ "(:\\d+)?")) (\_ -> "")
+
+
+parsePath : String -> List String
+parsePath str =
+    str
+        |> split "/"
+        |> List.filter notEmpty
+        |> List.map Http.decodeUri
+        |> List.map (Maybe.withDefault "")
+
+
+pathFromAll : String -> List String
+pathFromAll str =
+    parsePath (extractPath str)
+
+
+hasLeadingSlashFromAll : String -> Bool
+hasLeadingSlashFromAll str =
+    Regex.contains (Regex.regex "^/") (extractPath str)
+
+
+hasTrailingSlashFromAll : String -> Bool
+hasTrailingSlashFromAll str =
+    Regex.contains (Regex.regex "/$") (extractPath str)
+
+
+
+-- FRAGMENT
+
+
+{-| Extract the hash (hash) from the url
+-}
+extractHash : String -> String
+extractHash str =
+    str
+        |> split "#"
+        |> List.drop 1
+        |> List.head
+        |> Maybe.withDefault ""
+
+
+hashFromAll : String -> String
+hashFromAll str =
+    extractHash str
+
+
+
+-- QUERY
+
+
+{-| Extract the query string from the url
+-}
+extractQuery : String -> String
+extractQuery str =
+    let
+        query =
+            str
+                |> split "?"
+                |> List.drop 1
+                |> List.head
+                |> Maybe.withDefault ""
+                |> split "#"
+                |> List.head
+                |> Maybe.withDefault ""
+    in
+        if String.isEmpty query then
+            ""
+        else
+            "?" ++ query
+
+
+
+-- "?a=1&b=2&a=3" --> [("a", "1"), ("b", "2"), ("a", "1")]
+
+
+parseQuery : String -> Query
+parseQuery =
+    Erl.Query.parse
+
+
+queryFromAll : String -> Query
+queryFromAll all =
+    all
+        |> extractQuery
+        |> parseQuery
+
+
+{-| Parse a url string, returns an Erl.Url record
+
+    Erl.parse "http://api.example.com/users/1#x/1?a=1" == Erl.Url{...}
+
+-}
+parse : String -> Url
+parse str =
+    { host = (host str)
+    , hash = (hashFromAll str)
+    , password = ""
+    , path = (pathFromAll str)
+    , hasLeadingSlash = (hasLeadingSlashFromAll str)
+    , hasTrailingSlash = (hasTrailingSlashFromAll str)
+    , port_ = (extractPort str)
+    , protocol = (extractProtocol str)
+    , query = (queryFromAll str)
+    , username = ""
+    }
+
+
+
+-- TO STRING
+
+
+{-| Convert to a string only the query component of an url, this includes '?'
+
+    Erl.queryToString url == "?a=1&b=2"
+
+-}
+queryToString : Url -> String
+queryToString =
+    .query
+        >> Erl.Query.toString
+
+
+protocolComponent : Url -> String
+protocolComponent url =
+    case url.protocol of
+        "" ->
+            ""
+
+        _ ->
+            url.protocol ++ "://"
+
+
+hostComponent : Url -> String
+hostComponent url =
+    Http.encodeUri (join "." url.host)
+
+
+portComponent : Url -> String
+portComponent url =
+    case url.port_ of
+        0 ->
+            ""
+
+        80 ->
+            ""
+
+        443 ->
+            if url.protocol == "https" then
+                ""
+            else
+                ":443"
+
+        _ ->
+            ":" ++ (Basics.toString url.port_)
+
+
+pathComponent : Url -> String
+pathComponent url =
+    let
+        encoded =
+            List.map Http.encodeUri url.path
+
+        leadingSlash =
+            if hostComponent url /= "" || url.hasLeadingSlash then
+                "/"
+            else
+                ""
+    in
+        if (List.length url.path) == 0 then
+            ""
+        else
+            leadingSlash ++ (join "/" encoded)
+
+
+trailingSlashComponent : Url -> String
+trailingSlashComponent url =
+    if url.hasTrailingSlash == True then
+        "/"
+    else
+        ""
+
+
+{-| Convert to a string the hash component of an url, this includes '#'
+
+    hashToString url == "#a/b"
+
+-}
+hashToString : Url -> String
+hashToString url =
+    if String.isEmpty url.hash then
+        ""
+    else
+        "#" ++ url.hash
+
+
+{-| Generate an empty Erl.Url record
+
+    Erl.new ==
+
+    { protocol = ""
+    , username = ""
+    , password = ""
+    , host = []
+    , path = []
+    , hasLeadingSlash = False
+    , hasTrailingSlash = False
+    , port_ = 0
+    , hash = ""
+    , query = Dict.empty
+    }
+
+-}
+new : Url
+new =
+    { protocol = ""
+    , username = ""
+    , password = ""
+    , host = []
+    , path = []
+    , hasLeadingSlash = False
+    , hasTrailingSlash = False
+    , port_ = 0
+    , hash = ""
+    , query = []
+    }
+
+
+{-| Clears the current query string
+
+    Erl.clearQuery url
+
+-}
+clearQuery : Url -> Url
+clearQuery url =
+    { url | query = [] }
+
+
+{-| Adds key/value in query string
+
+    Erl.addQuery key value url
+
+This doesn't replace existing keys, so if this is a duplicated this key is just added.
+
+-}
+addQuery : String -> String -> Url -> Url
+addQuery key val url =
+    { url | query = Erl.Query.add key val url.query }
+
+
+{-| Set key/value in query string, removes any existing one if necessary.
+
+    Erl.setQuery key value url
+
+-}
+setQuery : String -> String -> Url -> Url
+setQuery key val url =
+    { url | query = Erl.Query.set key val url.query }
+
+
+{-| Removes key from query string
+
+    Erl.removeQuery key url
+
+-}
+removeQuery : String -> Url -> Url
+removeQuery key url =
+    { url | query = Erl.Query.remove key url.query }
+
+
+{-| Gets values for a key in the query
+
+    url = Erl.parse "?a=1&b=2&a=3"
+
+    Erl.getQueryValuesForKey "a" url
+
+    == ["1", "3"]
+
+-}
+getQueryValuesForKey : String -> Url -> List String
+getQueryValuesForKey key url =
+    Erl.Query.getValuesForKey key url.query
+
+
+{-| Append some path segments to a url
+
+    Erl.appendPathSegments ["hello", "world"] url
+
+-}
+appendPathSegments : List String -> Url -> Url
+appendPathSegments segments url =
+    let
+        newPath =
+            List.append url.path segments
+    in
+        { url | path = newPath }
+
+
+{-| Generate a url string from an Erl.Url record
+
+    url = { protocol = "http",
+          , username = "",
+          , password = "",
+          , host = ["www", "foo", "com"],
+          , path = ["users", "1"],
+          , hasLeadingSlash = False
+          , hasTrailingSlash = False
+          , port_ = 2000,
+          , hash = "a/b",
+          , query = Dict.empty |> Dict.insert "q" "1" |> Dict.insert "k" "2"
+          }
+
+    Erl.toString url == "http://www.foo.com:2000/users/1?k=2&q=1#a/b"
+
+-}
+toString : Url -> String
+toString url =
+    let
+        protocol_ =
+            protocolComponent url
+
+        host_ =
+            hostComponent url
+
+        port_ =
+            portComponent url
+    in
+        protocol_ ++ host_ ++ port_ ++ toAbsoluteString url
+
+
+{-| Generate a url that starts at the path
+
+    url = { protocol = "http",
+          , username = "",
+          , password = "",
+          , host = ["www", "foo", "com"],
+          , path = ["users", "1"],
+          , hasLeadingSlash = False
+          , hasTrailingSlash = False
+          , port_ = 2000,
+          , hash = "a/b",
+          , query = Dict.empty |> Dict.insert "q" "1" |> Dict.insert "k" "2"
+          }
+
+    Erl.toAbsoluteString url == "/users/1?k=2&q=1#a/b"
+
+-}
+toAbsoluteString : Url -> String
+toAbsoluteString url =
+    let
+        path_ =
+            pathComponent url
+
+        trailingSlash_ =
+            trailingSlashComponent url
+
+        query_ =
+            queryToString url
+
+        hash =
+            hashToString url
+    in
+        path_ ++ trailingSlash_ ++ query_ ++ hash

--- a/src/Erl/Query.elm
+++ b/src/Erl/Query.elm
@@ -1,0 +1,157 @@
+module Erl.Query
+    exposing
+        ( parse
+        , toString
+        , add
+        , set
+        , remove
+        , getValuesForKey
+        )
+
+{-| Functions to work with a Query record
+
+
+# Parse
+
+@docs parse
+
+
+# Mutation helpers
+
+@docs add, set, remove
+
+
+# Serialize
+
+@docs toString
+
+
+# Other helpers
+
+@docs getValuesForKey
+
+-}
+
+import Erl.Types as Types
+import Http
+import String
+
+
+{-| Parse a query string
+
+    Erl.Query.parse "?a=1&b=2&a=3" == [("a", "1"), ("b", "2"), ("a", "1")]
+
+-}
+parse : String -> Types.Query
+parse queryString =
+    let
+        trimmed =
+            queryString
+                |> String.split "?"
+                |> String.join ""
+
+        splitted =
+            String.split "&" trimmed
+    in
+        if String.isEmpty trimmed then
+            []
+        else
+            List.map queryStringElementToTuple splitted
+
+
+
+-- "a=1" --> ("a", "1")
+
+
+queryStringElementToTuple : String -> ( String, String )
+queryStringElementToTuple element =
+    let
+        splitted =
+            String.split "=" element
+
+        first =
+            Maybe.withDefault "" (List.head splitted)
+
+        firstDecoded =
+            Http.decodeUri first |> Maybe.withDefault ""
+
+        second =
+            Maybe.withDefault "" (List.head (List.drop 1 splitted))
+
+        secondDecoded =
+            Http.decodeUri second |> Maybe.withDefault ""
+    in
+        ( firstDecoded, secondDecoded )
+
+
+{-| Convert to a string, this includes '?'
+
+    Erl.Query.toString query == "?a=1&b=2"
+
+-}
+toString : Types.Query -> String
+toString query =
+    let
+        encodedTuples =
+            List.map (\( x, y ) -> ( Http.encodeUri x, Http.encodeUri y )) query
+
+        parts =
+            List.map (\( a, b ) -> a ++ "=" ++ b) encodedTuples
+    in
+        if List.isEmpty query then
+            ""
+        else
+            "?" ++ (String.join "&" parts)
+
+
+{-| Adds key/value in query string
+
+    Erl.Query.add key value query
+
+This doesn't replace existing keys, so if this is a duplicated this key is just added.
+
+-}
+add : String -> String -> Types.Query -> Types.Query
+add key val =
+    List.reverse
+        >> (::) ( key, val )
+        >> List.reverse
+
+
+{-| Set key/value in query string, removes any existing one if necessary.
+
+    Erl.Query.set key value query
+
+-}
+set : String -> String -> Types.Query -> Types.Query
+set key val query =
+    let
+        without =
+            remove key query
+    in
+        add key val without
+
+
+{-| Removes key from query string
+
+    Erl.Query.remove key query
+
+-}
+remove : String -> Types.Query -> Types.Query
+remove key query =
+    List.filter (\( k, v ) -> k /= key) query
+
+
+{-| Gets values for a key in the query
+
+    url = Erl.parse "?a=1&b=2&a=3"
+
+    Erl.Query.getQueryValuesForKey "a" url.query
+
+    == ["1", "3"]
+
+-}
+getValuesForKey : String -> Types.Query -> List String
+getValuesForKey key =
+    List.filter (\( k, _ ) -> k == key)
+        >> List.map Tuple.second

--- a/src/Erl/Types.elm
+++ b/src/Erl/Types.elm
@@ -1,0 +1,5 @@
+module Erl.Types exposing (..)
+
+
+type alias Query =
+    List ( String, String )

--- a/src/Redirects/Dump.elm
+++ b/src/Redirects/Dump.elm
@@ -2,6 +2,7 @@ module Redirects.Dump exposing (dump, stringRule)
 
 import Dict exposing (Dict)
 import Erl
+import Http exposing (decodeUri)
 import List
 import Redirects.Parser exposing (Rule, Conditions)
 
@@ -32,20 +33,39 @@ concatRule head tail response =
 
 stringRule : Rule -> String
 stringRule rule =
-    "\n[[redirects]]"
-        ++ "\nfrom = \""
-        ++ (Erl.toString rule.origin)
-        ++ "\""
-        ++ (mapQuery rule.params "query")
-        ++ "\nto = \""
-        ++ (Erl.toString rule.target.url)
-        ++ "\""
-        ++ "\nstatus = "
-        ++ (String.toLower (toString rule.target.status))
-        ++ "\nforce = "
-        ++ (String.toLower (toString rule.target.force))
-        ++ (mapConditions rule.conditions)
-        ++ "\n"
+    let
+        fromS =
+            Erl.toString rule.origin
+
+        from =
+            fromS |> decodeUri |> Maybe.withDefault fromS
+
+        toS =
+            Erl.toString rule.target.url
+
+        to =
+            toS |> decodeUri |> Maybe.withDefault toS
+
+        status =
+            rule.target.status |> toString |> String.toLower
+
+        force =
+            rule.target.force |> toString |> String.toLower
+    in
+        "\n[[redirects]]"
+            ++ "\nfrom = \""
+            ++ from
+            ++ "\""
+            ++ (mapQuery rule.params "query")
+            ++ "\nto = \""
+            ++ to
+            ++ "\""
+            ++ "\nstatus = "
+            ++ status
+            ++ "\nforce = "
+            ++ force
+            ++ (mapConditions rule.conditions)
+            ++ "\n"
 
 
 mapQuery : Conditions -> String -> String

--- a/tests/Redirects/DumpTests.elm
+++ b/tests/Redirects/DumpTests.elm
@@ -21,6 +21,8 @@ suite =
             \() -> Expect.equal multipleRules dumpMultipleRules
         , test "rule with signature" <|
             \() -> Expect.equal ruleWithSignature dumpRuleWithSignature
+        , test "rule with placeholders" <|
+            \() -> Expect.equal ruleWithPlaceholders dumpRuleWithPlaceholders
         ]
 
 
@@ -91,6 +93,17 @@ dumpRuleWithSignature =
         dump [ rule ]
 
 
+dumpRuleWithPlaceholders =
+    let
+        target =
+            (Target (Erl.parse "/:place2/:place1/:splat") 301 False False)
+
+        rule =
+            (Rule (Erl.parse "/:place1/:place2/*") Dict.empty target Dict.empty)
+    in
+        dump [ rule ]
+
+
 simpleRule =
     """
 [[redirects]]
@@ -148,4 +161,14 @@ to = "/foo"
 status = 301
 force = false
 signed = "API_SIGNATURE_TOKEN"
+"""
+
+
+ruleWithPlaceholders =
+    """
+[[redirects]]
+from = "/:place1/:place2/*"
+to = "/:place2/:place1/:splat"
+status = 301
+force = false
 """

--- a/tests/Redirects/DumpTests.elm
+++ b/tests/Redirects/DumpTests.elm
@@ -96,10 +96,10 @@ dumpRuleWithSignature =
 dumpRuleWithPlaceholders =
     let
         target =
-            (Target (Erl.parse "/:place2/:place1/:splat") 301 False False)
+            (Target (Erl.parse "https://example.com/:place2/:place1/:splat") 301 False False)
 
         rule =
-            (Rule (Erl.parse "/:place1/:place2/*") Dict.empty target Dict.empty)
+            (Rule (Erl.parse "https://example.com/:place1/:place2/*") Dict.empty target Dict.empty)
     in
         dump [ rule ]
 
@@ -167,8 +167,8 @@ signed = "API_SIGNATURE_TOKEN"
 ruleWithPlaceholders =
     """
 [[redirects]]
-from = "/:place1/:place2/*"
-to = "/:place2/:place1/:splat"
+from = "https://example.com/:place1/:place2/*"
+to = "https://example.com/:place2/:place1/:splat"
 status = 301
 force = false
 """

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -14,6 +14,7 @@
         "elm-community/list-extra": "6.0.0 <= v < 7.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "elm-lang/navigation": "2.0.1 <= v < 3.0.0",
         "evancz/url-parser": "2.0.1 <= v < 3.0.0",
         "sporto/erl": "10.0.2 <= v < 11.0.0"

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -16,8 +16,7 @@
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "elm-lang/navigation": "2.0.1 <= v < 3.0.0",
-        "evancz/url-parser": "2.0.1 <= v < 3.0.0",
-        "sporto/erl": "10.0.2 <= v < 11.0.0"
+        "evancz/url-parser": "2.0.1 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
Erl encodes the path when printing a URL, we want to preserve the
original format.

Fixes #23

Signed-off-by: David Calavera <david.calavera@gmail.com>